### PR TITLE
update operator image to 2.0.0

### DIFF
--- a/deploy/example/operator.yaml
+++ b/deploy/example/operator.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: topolvm-operator
           # set the stable version
-          image: alaudapublic/topolvm-operator:1.0.0
+          image: alaudapublic/topolvm-operator:2.0.0
           command:
             - /topolvm
           args:


### PR DESCRIPTION
Updated Operator image in the `deploy/example/operator.yaml` to `alaudapublic/topolvm-operator:2.0.0`

fixes: #15 
Signed-off-by: Santosh Pillai <sapillai@redhat.com>