### PR TITLE
[WIP]adds SCC to deploy topolvm on openshift environment

### DIFF
--- a/api/v2/scc.go
+++ b/api/v2/scc.go
@@ -1,0 +1,56 @@
+package v2
+
+import (
+	"fmt"
+
+	secv1 "github.com/openshift/api/security/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewSecurityContextConstraints returns a new SecurityContextConstraints for topolvm to run on
+// OpenShift.
+func NewSecurityContextConstraints(name, namespace string) *secv1.SecurityContextConstraints {
+	return &secv1.SecurityContextConstraints{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "security.openshift.io/v1",
+			Kind:       "SecurityContextConstraints",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		AllowPrivilegedContainer: true,
+		AllowHostDirVolumePlugin: true,
+		ReadOnlyRootFilesystem:   false,
+		AllowHostPID:             true,
+		AllowHostIPC:             true,
+		AllowHostNetwork:         false,
+		AllowHostPorts:           false,
+		RequiredDropCapabilities: []corev1.Capability{},
+		DefaultAddCapabilities:   []corev1.Capability{},
+		RunAsUser: secv1.RunAsUserStrategyOptions{
+			Type: secv1.RunAsUserStrategyRunAsAny,
+		},
+		SELinuxContext: secv1.SELinuxContextStrategyOptions{
+			Type: secv1.SELinuxStrategyMustRunAs,
+		},
+		FSGroup: secv1.FSGroupStrategyOptions{
+			Type: secv1.FSGroupStrategyMustRunAs,
+		},
+		SupplementalGroups: secv1.SupplementalGroupsStrategyOptions{
+			Type: secv1.SupplementalGroupsStrategyRunAsAny,
+		},
+		Volumes: []secv1.FSType{
+			secv1.FSTypeConfigMap,
+			secv1.FSTypeEmptyDir,
+			secv1.FSTypeHostPath,
+			secv1.FSTypeSecret,
+		},
+		Users: []string{
+			fmt.Sprintf("system:serviceaccount:%s:topolvm-node", namespace),
+			fmt.Sprintf("system:serviceaccount:%s:topolvm-discover", namespace),
+			fmt.Sprintf("system:serviceaccount:%s:topolvm-preparevg", namespace),
+		},
+	}
+}

--- a/api/v2/scc_test.go
+++ b/api/v2/scc_test.go
@@ -1,0 +1,14 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSecurityContextConstraints(t *testing.T) {
+	name := "topolvm"
+	scc := NewSecurityContextConstraints(name, name)
+	assert.True(t, scc.AllowPrivilegedContainer)
+	assert.Equal(t, name, scc.Name)
+}

--- a/deploy/example/operator-openshift.yaml
+++ b/deploy/example/operator-openshift.yaml
@@ -1,0 +1,75 @@
+# scc for the topolvm deployment and daemonsets
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: topolvm
+allowPrivilegedContainer: true
+allowHostDirVolumePlugin: true
+priority:
+allowHostNetwork: false
+allowHostPorts: false
+allowedCapabilities: []
+allowHostPID: true
+allowHostIPC: true
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+defaultAddCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - emptyDir
+  - hostPath
+  - secret
+users:
+  - system:serviceaccount:topolvm-system:topolvm-node
+  - system:serviceaccount:topolvm-system:topolvm-discover
+  - system:serviceaccount:topolvm-system:topolvm-preparevg
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: topolvm-operator
+  namespace: topolvm-system
+  labels:
+    operator: topolvm
+spec:
+  selector:
+    matchLabels:
+      app: topolvm-operator
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: topolvm-operator
+    spec:
+      serviceAccountName: topolvm-operator
+      containers:
+        - name: topolvm-operator
+          # set the stable version
+          image: alaudapublic/topolvm-operator:2.1.0
+          command:
+            - /topolvm
+          args:
+            - operator
+          env:
+            - name: TOPOLVM_LOG_LEVEL
+              value: "DEBUG"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: IS_OPERATOR_HUB
+              value: "0"

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
+	github.com/openshift/api v0.0.0-20190322043348-8741ff068a47
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.50.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.50.0

--- a/go.sum
+++ b/go.sum
@@ -1047,6 +1047,7 @@ github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rm
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/openlyinc/pointy v1.1.2/go.mod h1:w2Sytx+0FVuMKn37xpXIAyBNhFNBIJGR/v2m7ik1WtM=
+github.com/openshift/api v0.0.0-20190322043348-8741ff068a47 h1:PAlaAXvwmPxgh8gm0/eVmNMGLeJ1bURwyKvJVLnsr6s=
 github.com/openshift/api v0.0.0-20190322043348-8741ff068a47/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20180830153425-431ec9a26e50/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/cluster-api v0.0.0-20191129101638-b09907ac6668/go.mod h1:T18COkr6nLh9RyZKPMP7YjnwBME7RX8P2ar1SQbBltM=


### PR DESCRIPTION
This PR:
1. Creates a new `operator-openshift.yaml` manifest file. This file is to be used while deploying operator on openshift environment. 
2. Provides a `go` representation of the SCCs. This can be useful for other deployers (for example: another operator) that are trying to deploy topolvm operator on openshift. 
2. Applying this new manifest file will create the operator and will also create a new SCC that provides required privileges to the `topolvm-node` , `topolvm-discover` and `topolvm-preparevg` service accounts. 

fixes: #49 

Signed-off-by: Santosh Pillai <sapillai@redhat.com>